### PR TITLE
fix: update URLs, correct typos, and improve clarity in documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -120,5 +120,5 @@
 ## Community
 
 * [Discord](https://discord.gg/H34KZqF)
-* [Twitter](https://twitter.com/BloctoApp)
+* [Twitter](https://x.com/BloctoApp)
 * [Facebook](https://www.facebook.com/blocto/)

--- a/blocto-app/deep-linking.md
+++ b/blocto-app/deep-linking.md
@@ -4,7 +4,7 @@ description: Open your dApp with Blocto in one click
 
 # Deep Linking
 
-> With Blocto deep link, you can boost the conversion rate new sign-ups. According to our partners, it has improved from **5%** to **80%**
+> With Blocto deep link, you can boost the conversion rate of new sign-ups. According to our partners, it has improved from **5%** to **80%**
 
 ### Usage
 
@@ -13,7 +13,7 @@ https://blocto.app/link?url=URL&blockchains=BLOCKCHAINS
 ```
 
 * `URL`: the URL of your dApp
-* `BLOCKCHAINS`: (optional) blockchains you dApp use, comma separated. `ethereum/tron/flow/bsc/solana/polygon/avalanche`
+* `BLOCKCHAINS`: (optional) blockchains your dApp uses, comma separated. `ethereum/tron/flow/bsc/solana/polygon/avalanche`
 
 For example:
 

--- a/blocto-app/sending-rewards.md
+++ b/blocto-app/sending-rewards.md
@@ -26,7 +26,7 @@ Content-Type: application/json
 {% endswagger-description %}
 
 {% swagger-parameter in="body" name="blockchain" type="string" %}
-dApp blockchain
+dApp's blockchain
 {% endswagger-parameter %}
 
 {% swagger-parameter in="body" name="wallet_address" type="string" %}

--- a/blocto-sdk/android-sdk/ethereum-bsc-polygon-avalanche.md
+++ b/blocto-sdk/android-sdk/ethereum-bsc-polygon-avalanche.md
@@ -18,9 +18,9 @@ Note that Blocto Android SDK for EVM is still in **Beta**. APIs are subject to b
   * Send transactions
   * ... and a lot more
 * **Seamless onboarding experience**\
-  Users can sign up easily with email and start exploring you dApp in seconds.
+  Users can sign up easily with email and start exploring your dApp in seconds.
 * **Fee subsidization**\
-  You have the option to pay transaction fee for your users and provide a better experience. In that case, we will generate daily fee reports for you to review.
+  You have the option to pay transaction fees for your users and provide a better experience. In that case, we will generate daily fee reports for you to review.
 * **Integrated payment**\
   Get paid easily with our payment APIs. Users can pay easily with credit cards or other crypto currencies like Bitcoin, Ethereum, Tron, USDT, ...
 * **Connected to Blocto App**\


### PR DESCRIPTION
fix: update URLs, correct typos, and improve clarity in documentation

- Replaced outdated Twitter URL with updated x.com format
- Improved clarity in rewards documentation: changed "send reward to your users as a way of incentive" to "send rewards to your users as an incentive"
- Corrected "dApp blockchain" to "dApp's blockchain"
- Fixed typos in EVM SDK documentation:
  - "exploring you dApp in seconds" to "exploring your dApp in seconds"
  - "transaction fee for your users" to "transaction fees for your users"
  - "BSC Mainnet & Tesnet" to "BSC Mainnet & Testnet"
